### PR TITLE
Allow mounting host machine directory as /data

### DIFF
--- a/templates/_deployment.yaml
+++ b/templates/_deployment.yaml
@@ -34,10 +34,15 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .Chart.Name }}
         {{- end }}
-        {{- if .Values.dataVolume }}
+        {{- if .Values.dataVolume.pvc }}
         - name: {{ .Chart.Name }}-data
           persistentVolumeClaim:
             claimName: {{ .Chart.Name }}-data
+        {{- else if .Values.dataVolume.hostPath }}
+        - name: {{ .Chart.Name }}-data
+          hostPath:
+            path: {{ .Values.dataVolume.hostPath }}
+            type: Directory
         {{- end }}
         - name: config-volume
           configMap:
@@ -56,9 +61,12 @@ spec:
         - name: {{ .Chart.Name }}
           mountPath: /autosave
         {{- end }}
-        {{- if .Values.dataVolume }}
+        {{- if or (.Values.dataVolume.pvc) (.Values.dataVolume.hostPath)  }}
         - name: {{ .Chart.Name }}-data
           mountPath: /data
+          {{- if .Values.dataVolume.hostPath }}
+          mountPropagation: HostToContainer
+          {{- end}}
         {{- end }}
         stdin: true
         tty: true

--- a/templates/_ioc-volume.yaml
+++ b/templates/_ioc-volume.yaml
@@ -18,7 +18,7 @@ spec:
       storage: 10Mi
 {{- end }}
 
-{{- if .Values.dataVolume }}
+{{- if .Values.dataVolume.pvc }}
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/values.yaml
+++ b/values.yaml
@@ -15,8 +15,12 @@ exports:
     # provide a PVC for autosave mounted at /autosave
     autosave: false
 
-    # a PVC to mount at /data if needed
+    # Somewhere to mount at /data if needed
     dataVolume:
+      # A PVC to write data into
+      pvc: false
+      # A path on the host machine to write data into, ignored if dataVolume.pvc is true
+      hostPath: ""
 
     # set this to your namespace service account
     serviceAccount: epics-iocs-priv


### PR DESCRIPTION
Provide config in `values.yaml` so that an IOC can optionally mount `/data` either as a PVC or a host path, allowing it to write to the detector machine's filesystem or any filesystems it mounts.