### PR TITLE
remove explicit namespaces

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -6,16 +6,16 @@
   {{- end }}
 {{- end }}
 {{- else if contains "NodePort" .Values.service.type }}
-  export NODE_PORT=$(kubectl get --namespace {{ .Values.namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ioc-chart.fullname" . }})
-  export NODE_IP=$(kubectl get nodes --namespace {{ .Values.namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  export NODE_PORT=$(kubectl get  -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "ioc-chart.fullname" . }})
+  export NODE_IP=$(kubectl get nodes -o jsonpath="{.items[0].status.addresses[0].address}")
   echo http://$NODE_IP:$NODE_PORT
 {{- else if contains "LoadBalancer" .Values.service.type }}
      NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-           You can watch the status of by running 'kubectl get --namespace {{ .Values.namespace }} svc -w {{ include "ioc-chart.fullname" . }}'
-  export SERVICE_IP=$(kubectl get svc --namespace {{ .Values.namespace }} {{ include "ioc-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+           You can watch the status of by running 'kubectl get svc -w {{ include "ioc-chart.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc {{ include "ioc-chart.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
   echo http://$SERVICE_IP:{{ .Values.service.port }}
 {{- else if contains "ClusterIP" .Values.service.type }}
-  export POD_NAME=$(kubectl get pods --namespace {{ .Values.namespace }} -l "app.kubernetes.io/name={{ include "ioc-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export POD_NAME=$(kubectl get pods -l "app.kubernetes.io/name={{ include "ioc-chart.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
   echo "Visit http://127.0.0.1:8080 to use your application"
-  kubectl --namespace {{ .Values.namespace }} port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:80
 {{- end }}

--- a/templates/_configmap.tpl
+++ b/templates/_configmap.tpl
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name:  {{ .Chart.Name }}
-  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Chart.Name }}
     beamline: {{ .Values.beamline }}

--- a/templates/_deployment.yaml
+++ b/templates/_deployment.yaml
@@ -27,7 +27,7 @@ spec:
     spec:
       serviceAccountName: {{ .Values.serviceAccount | default "epics-iocs-priv" | quote }}
       hostNetwork: {{ .Values.hostNetwork }}
-      terminationGracePeriodSeconds: 5 # nice to have quick restarts on IOCs
+      terminationGracePeriodSeconds: 15 # nice to have quick restarts on IOCs
       volumes:
         {{- if .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
@@ -58,7 +58,19 @@ spec:
         command:
           - bash
         args:
-          - {{ .Values.iocFolder }}/config/start.sh
+          - {{ .Values.iocFolder }}/start.sh
+        livenessProbe:
+          exec:
+            command:
+            - /bin/bash
+            - /repos/epics/ioc/liveness.sh
+          initialDelaySeconds: 120
+          periodSeconds: 10
+        lifecycle:
+          preStop:
+            exec:
+              # TODO move this up into ioc folder (in ioc-template itself)
+              command: ["bash", "-c", "/repos/epics/ioc/stop.sh"]
         volumeMounts:
         - name: config-volume
           mountPath: {{ .Values.iocFolder }}/config

--- a/templates/_deployment.yaml
+++ b/templates/_deployment.yaml
@@ -4,7 +4,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ .Chart.Name }}
-  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Chart.Name }}
     beamline: {{ .Values.beamline }}
@@ -25,7 +24,9 @@ spec:
         ioc_version: {{ .Chart.AppVersion | quote }}
         is_ioc: "True"
     spec:
+      {{ if .Values.serviceAccountName }}
       serviceAccountName: {{ .Values.serviceAccount | default "epics-iocs-priv" | quote }}
+      {{- end }}
       hostNetwork: {{ .Values.hostNetwork }}
       terminationGracePeriodSeconds: 15 # nice to have quick restarts on IOCs
       volumes:

--- a/templates/_deployment.yaml
+++ b/templates/_deployment.yaml
@@ -73,10 +73,11 @@ spec:
           mountPropagation: HostToContainer
           {{- end}}
         {{- end }}
-        {{ if .nfsv2TftpClaim }}
+        {{- if .Values.nfsv2TftpClaim }}
         - name: nfsv2-tftp-volume
-          mountPath: /tftp_nfsv2
-        {{- end -}}
+          mountPath: /nfsv2-tftp
+          subPath: "{{ .Values.beamline }}/{{ .Chart.Name }}"
+          {{- end }}
         stdin: true
         tty: true
         securityContext:

--- a/templates/_ioc-volume.yaml
+++ b/templates/_ioc-volume.yaml
@@ -6,7 +6,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Chart.Name }}
-  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Chart.Name }}
     beamline: {{ .Values.beamline }}
@@ -24,7 +23,6 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: {{ .Chart.Name }}-data
-  namespace: {{ .Values.namespace }}
   labels:
     app: {{ .Chart.Name }}
     beamline: {{ .Values.beamline }}

--- a/templates/_service.yaml
+++ b/templates/_service.yaml
@@ -4,7 +4,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Chart.Name }}-tcp
-  namespace: {{ .Values.namespace }}
   annotations:
     metallb.universe.tf/allow-shared-ip: {{ .Chart.Name }}
   labels:
@@ -26,7 +25,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Chart.Name }}-udp
-  namespace: {{ .Values.namespace }}
   annotations:
     metallb.universe.tf/allow-shared-ip: {{ .Chart.Name }}
   labels:

--- a/values.yaml
+++ b/values.yaml
@@ -3,7 +3,6 @@
 # Declare variables to be passed into your templates.
 exports:
   defaults:
-    namespace: epics-iocs
     beamline: no-beamline! (always override this)
 
     # to support channel access and other protocols we need to run in host's network
@@ -22,8 +21,9 @@ exports:
       # A path on the host machine to write data into, ignored if dataVolume.pvc is true
       hostPath: ""
 
-    # set this to your namespace service account
-    serviceAccount: epics-iocs-priv
+    # set this to your enforce namespace service account
+    # leave blank for default service account
+    # serviceAccount: epics-iocs-priv
 
     # provide some reasonable defaults here but allow override
     securityContext:


### PR DESCRIPTION
it is better to allow helm to override the namespace and the `ec` tools will supply a namespace always.